### PR TITLE
Updates to resolve the unknown errors

### DIFF
--- a/FG2021-Base.h
+++ b/FG2021-Base.h
@@ -339,7 +339,7 @@ struct AttractLampsSiren AttractLampsSiren[] = {
     {LA_STAR_SHOOTER_TOP, 33}
 };
 
-#define NUM_OF_ATTRACT_LAMPS_MING_ATTACK 63
+#define NUM_OF_ATTRACT_LAMPS_MING_ATTACK 60
 struct AttractLampsMingAttack {
   byte lightNumMingAttack;
   byte rowMingAttack;


### PR DESCRIPTION
Turned ming lamps on, instead of off, in NormalGamePlay
Updated AddPlayer function to properly handle resetNumPlayers
Removed unused logic to see if saucer x-ball was collected on InitNewBall
Removed unused logic from AttractRetro
Removed unused variable in InitNewBall (byte playerNum)
Removed unused logic in handle dtarget 3 lights
Adjusted MingAttackProgress saucer lamp animation logic
Removed unused logic in ming defeated for logic (return)
Adjusted number of lamps in AttractLampsMingAttack to be correct
Adjusted machine state since there is no selftest currently
Commented out highScorePlayerNum from ShowMatchSequence (unused)